### PR TITLE
Change to UID and GID handling in containers

### DIFF
--- a/docker/base/scripts/docker-entrypoint.sh
+++ b/docker/base/scripts/docker-entrypoint.sh
@@ -6,10 +6,11 @@
 #
 # Add a local using the USER and UID passed in, or fallback.
 
-UID=${UID:-9001}
+UID=${UID:-1001}
 USER=${USER:-user}
 
 echo "Starting with USER: $USER, UID: $UID"
+
 useradd --shell /bin/bash --uid $UID \
         --non-unique --create-home $USER --comment ""
 

--- a/docker/conda/scripts/docker-entrypoint.sh
+++ b/docker/conda/scripts/docker-entrypoint.sh
@@ -2,10 +2,15 @@
 
 set -ex
 
-CONDA_USER_ID=${CONDA_USER_ID:-9001}
+CONDA_USER_ID=${CONDA_USER_ID:-1001}
 CONDA_USER=${CONDA_USER:-conda}
 CONDA_GROUP_ID=${CONDA_GROUP_ID:-32001}
 CONDA_INSTALL_DIR=${CONDA_INSTALL_DIR:-/opt/conda}
+
+echo "Starting with USER: $CONDA_USER, " \
+     "UID: $CONDA_USER_ID, GID: $CONDA_GROUP_ID"
+
+groupadd --gid $CONDA_GROUP_ID --force
 
 useradd --shell /bin/bash --uid $CONDA_USER_ID --gid $CONDA_GROUP_ID \
         --non-unique --create-home $CONDA_USER --comment ""


### PR DESCRIPTION
Make the default UID be 1001, rather than 9001.

In containers using Conda, create a new group with the specified GID,
if it does not alreqdy exist.