### PR TITLE
Update conda-build to 3.18.11

### DIFF
--- a/docker/conda/scripts/install_conda.sh
+++ b/docker/conda/scripts/install_conda.sh
@@ -25,7 +25,7 @@ CONDA_SHA256=${CONDA_SHA256:-"0d6b23895a91294a4924bd685a3a1f48e35a17970a073cd2f6
 CONDA_URL="https://repo.anaconda.com/miniconda/Miniconda$PYTHON_VERSION-$CONDA_VERSION-$OS-$ARCH.sh"
 
 # Conda package parameters
-CONDA_BUILD_VERSION=${CONDA_BUILD_VERSION:-"3.17.8"}
+CONDA_BUILD_VERSION=${CONDA_BUILD_VERSION:-"3.18.11"}
 
 CONDA_INSTALL_DIR=${CONDA_INSTALL_DIR:-/opt/conda}
 WORK_DIR=$(make_temp_dir)
@@ -35,13 +35,14 @@ sha256sum "$WORK_DIR/miniconda.sh" | grep $CONDA_SHA256
 /bin/sh "$WORK_DIR/miniconda.sh" -b -p "$CONDA_INSTALL_DIR"
 
 source $CONDA_INSTALL_DIR/etc/profile.d/conda.sh
+
 conda activate
 
 conda config --set auto_update_conda False
 conda config --set ssl_verify True
 conda config --set show_channel_urls True
 
-conda install -y python jinja2 networkx packaging pyaml setuptools
+conda install -y jinja2 networkx packaging pyaml setuptools
 conda install -y "conda-build=$CONDA_BUILD_VERSION" conda-verify
 
 pip install rfc3987


### PR DESCRIPTION
Update conda-build to 3.18.11

Don't explicitly install Python because this can install a version
incompatible with conda-build (unless we start pinning the Python
version).