### PR TITLE
Bugfix: setting the conda group GID

### DIFF
--- a/docker/conda/scripts/docker-entrypoint.sh
+++ b/docker/conda/scripts/docker-entrypoint.sh
@@ -10,7 +10,7 @@ CONDA_INSTALL_DIR=${CONDA_INSTALL_DIR:-/opt/conda}
 echo "Starting with USER: $CONDA_USER, " \
      "UID: $CONDA_USER_ID, GID: $CONDA_GROUP_ID"
 
-groupadd --gid $CONDA_GROUP_ID --force
+groupmod --gid $CONDA_GROUP_ID conda
 
 useradd --shell /bin/bash --uid $CONDA_USER_ID --gid $CONDA_GROUP_ID \
         --non-unique --create-home $CONDA_USER --comment ""
@@ -26,6 +26,7 @@ if [ ! -e "$HOME/.condarc" ]; then
 fi
 
 chown -R $USER:$USER /home/$USER
+chown -R $USER:conda "$CONDA_INSTALL_DIR"
 chmod g+w "$CONDA_INSTALL_DIR"
 
 exec gosu $USER "$@"

--- a/docker/conda/ubuntu/12.04/Dockerfile
+++ b/docker/conda/ubuntu/12.04/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && \
     /opt/docker/conda/scripts/install_conda.sh && \
     cp /root/.condarc /opt/conda/etc/condarc && \
     chmod +x /opt/docker/conda/scripts/docker-entrypoint.sh && \
-    groupadd -g $CONDA_GROUP_ID conda && \
+    groupadd --gid $CONDA_GROUP_ID conda && \
     chgrp -R conda /opt/conda && \
     chmod -R g=u /opt/conda
 


### PR DESCRIPTION
This fix uses groupmod to ensure that the conda GID is set to the
desired value in the entrypoint script.